### PR TITLE
Update to new channel API

### DIFF
--- a/ios/Classes/GoogleSignInPlugin.m
+++ b/ios/Classes/GoogleSignInPlugin.m
@@ -59,7 +59,6 @@
         }];
     } else if ([call.method isEqualToString:@"signOut"]) {
         [[GIDSignIn sharedInstance] signOut];
-        [self respondWithAccount:nil error:nil];
         result(nil);
     } else if ([call.method isEqualToString:@"disconnect"]) {
         [_accountRequests insertObject:result atIndex:0];


### PR DESCRIPTION
result callback now takes a single argument, which in error cases may be a FlutterError or the FlutterMethodNotImplemented constant. All other values are treated as a successful result.