### PR TITLE
basic connection management without FragmentActivity

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -32,7 +32,6 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:support-annotations:25.0.0'
-  compile 'com.google.android.gms:play-services-auth:9.0.0'
+  compile 'com.google.android.gms:play-services-auth:10.2.1'
   compile 'com.google.guava:guava:20.0'
 }

--- a/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -6,11 +6,11 @@ package io.flutter.plugins.googlesignin;
 
 import android.accounts.Account;
 import android.app.Activity;
+import android.app.Application.ActivityLifecycleCallbacks;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.app.FragmentActivity;
 import android.util.Log;
 import com.google.android.gms.auth.GoogleAuthUtil;
 import com.google.android.gms.auth.api.Auth;
@@ -29,31 +29,26 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import io.flutter.app.FlutterActivity;
-import io.flutter.view.FlutterView;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
-import io.flutter.plugin.common.FlutterMethodChannel;
-import io.flutter.plugin.common.FlutterMethodChannel.MethodCallHandler;
-import io.flutter.plugin.common.FlutterMethodChannel.Response;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
+import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.MethodCall;
 
 import java.util.HashMap;
-import java.util.Map;
 
 /**
- * GoogleSignIn
+ * Google sign-in plugin for Flutter.
  */
 public class GoogleSignInPlugin
     implements MethodCallHandler,
-        GoogleApiClient.ConnectionCallbacks,
-        GoogleApiClient.OnConnectionFailedListener {
+    GoogleApiClient.ConnectionCallbacks,
+    GoogleApiClient.OnConnectionFailedListener {
 
   private FlutterActivity activity;
   private final String CHANNEL = "plugins.flutter.io/google_sign_in";
@@ -76,12 +71,13 @@ public class GoogleSignInPlugin
   private static final String METHOD_DISCONNECT = "disconnect";
 
   private static final class PendingOperation {
-    final String method;
-    final Queue<Response> responseQueue = Lists.newLinkedList();
 
-    PendingOperation(String method, Response response) {
+    final String method;
+    final Queue<Result> resultQueue = Lists.newLinkedList();
+
+    PendingOperation(String method, Result result) {
       this.method = Preconditions.checkNotNull(method);
-      responseQueue.add(Preconditions.checkNotNull(response));
+      resultQueue.add(Preconditions.checkNotNull(result));
     }
   }
 
@@ -107,38 +103,41 @@ public class GoogleSignInPlugin
     this.activity = activity;
     this.backgroundTaskRunner = backgroundTaskRunner;
     this.requestCode = requestCode;
-    new FlutterMethodChannel(activity.getFlutterView(), CHANNEL)
-      .setMethodCallHandler(this);
+    activity.getApplication()
+        .registerActivityLifecycleCallbacks(new GoogleApiClientConnectionManager());
+    new MethodChannel(activity.getFlutterView(), CHANNEL)
+        .setMethodCallHandler(this);
   }
 
   @Override
-  public void onMethodCall(MethodCall call, Response response) {
+  public void onMethodCall(MethodCall call, Result result) {
+    @SuppressWarnings({"unchecked"})
     HashMap<String, Object> arguments = (HashMap<String, Object>) call.arguments;
     switch (call.method) {
       case METHOD_INIT:
-        init(response,
-            (List<String>) arguments.get("scopes"),
-            (String) arguments.get("hostedDomain"));
+        @SuppressWarnings({"unchecked"})
+        List<String> scopes = (List<String>) arguments.get("scopes");
+        init(result, scopes, (String) arguments.get("hostedDomain"));
         break;
 
       case METHOD_SIGN_IN_SILENTLY:
-        signInSilently(response);
+        signInSilently(result);
         break;
 
       case METHOD_SIGN_IN:
-        signIn(response);
+        signIn(result);
         break;
 
       case METHOD_GET_TOKEN:
-        getToken(response, (String) arguments.get("email"));
+        getToken(result, (String) arguments.get("email"));
         break;
 
       case METHOD_SIGN_OUT:
-        signOut(response);
+        signOut(result);
         break;
 
       case METHOD_DISCONNECT:
-        disconnect(response);
+        disconnect(result);
         break;
 
       default:
@@ -146,276 +145,315 @@ public class GoogleSignInPlugin
     }
   }
 
-   /**
-    * Initializes this listener so that it is ready to perform other operations. The Dart code
-    * guarantees that this will be called and completed before any other methods are invoked.
-    */
-   private void init(Response response, List<String> requestedScopes, String hostedDomain) {
-     try {
-       if (googleApiClient != null) {
-         // This can happen if the scopes change, or a full restart hot reload
-         googleApiClient.stopAutoManage(activity);
-         googleApiClient = null;
-       }
-       GoogleSignInOptions.Builder optionsBuilder =
-           new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN);
-       optionsBuilder.requestEmail();
-       for (String scope : requestedScopes) {
-         optionsBuilder.requestScopes(new Scope(scope));
-       }
-       if (!Strings.isNullOrEmpty(hostedDomain)) {
-         optionsBuilder.setHostedDomain(hostedDomain);
-       }
+  /**
+   * Initializes this listener so that it is ready to perform other operations. The Dart code
+   * guarantees that this will be called and completed before any other methods are invoked.
+   */
+  private void init(Result result, List<String> requestedScopes, String hostedDomain) {
+    try {
+      if (googleApiClient != null) {
+        // This can happen if the scopes change, or a full restart hot reload
+        googleApiClient = null;
+      }
+      GoogleSignInOptions.Builder optionsBuilder =
+          new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN);
+      optionsBuilder.requestEmail();
+      for (String scope : requestedScopes) {
+        optionsBuilder.requestScopes(new Scope(scope));
+      }
+      if (!Strings.isNullOrEmpty(hostedDomain)) {
+        optionsBuilder.setHostedDomain(hostedDomain);
+      }
 
-       this.requestedScopes = requestedScopes;
-       this.googleApiClient =
-           new GoogleApiClient.Builder(activity)
-               .enableAutoManage(activity, this)
-               .addApi(Auth.GOOGLE_SIGN_IN_API, optionsBuilder.build())
-               .addConnectionCallbacks(this)
-               .build();
-     } catch (Exception e) {
-       Log.e(TAG, "Initialization error", e);
-       response.error(ERROR_REASON_EXCEPTION, e.getMessage(), null);
-     }
+      this.requestedScopes = requestedScopes;
+      this.googleApiClient =
+          new GoogleApiClient.Builder(activity)
+              .addApi(Auth.GOOGLE_SIGN_IN_API, optionsBuilder.build())
+              .addConnectionCallbacks(this)
+              .addOnConnectionFailedListener(this)
+              .build();
+      this.googleApiClient.connect();
+    } catch (Exception e) {
+      Log.e(TAG, "Initialization error", e);
+      result.error(ERROR_REASON_EXCEPTION, e.getMessage(), null);
+    }
 
-     // We're not initialized until we receive `onConnected`.
-     // If initialization fails, we'll receive `onConnectionFailed`
-     pendingOperation = new PendingOperation(METHOD_INIT, response);
-   }
+    // We're not initialized until we receive `onConnected`.
+    // If initialization fails, we'll receive `onConnectionFailed`
+    pendingOperation = new PendingOperation(METHOD_INIT, result);
+  }
 
-   /**
-    * Handles the case of a concurrent operation already in progress.
-    *
-    * <p>Only one type of operation is allowed to be executed at a time, so if there's a pending
-    * operation for a method type other than the current invocation, this will respond failure on the
-    * specified response channel. Alternatively, if there's a pending operation for the same method
-    * type, this will signal that the method is already being handled and add the specified response
-    * to the pending operation's response queue.
-    *
-    * <p>If there's no pending operation, this method will set the pending operation to the current
-    * invocation.
-    *
-    * @param currentMethod The current invocation.
-    * @param response The response channel for the current invocation.
-    * @return true iff an operation is already in progress (and thus the response is already being
-    *     handled).
-    */
-   private boolean checkAndSetPendingOperation(String currentMethod, Response response) {
-     if (pendingOperation == null) {
-       pendingOperation = new PendingOperation(currentMethod, response);
-       return false;
-     }
+  /**
+   * Handles the case of a concurrent operation already in progress.
+   *
+   * <p>Only one type of operation is allowed to be executed at a time, so if there's a pending
+   * operation for a method type other than the current invocation, this will report failure on the
+   * specified result object. Alternatively, if there's a pending operation for the same method
+   * type, this will signal that the method is already being handled and add the specified result
+   * to the pending operation's result queue.
+   *
+   * <p>If there's no pending operation, this method will set the pending operation to the current
+   * invocation.
+   *
+   * @param currentMethod The current invocation.
+   * @param result receives the result of the current invocation.
+   * @return true iff an operation is already in progress (and thus the response is already being
+   * handled).
+   */
+  private boolean checkAndSetPendingOperation(String currentMethod, Result result) {
+    if (pendingOperation == null) {
+      pendingOperation = new PendingOperation(currentMethod, result);
+      return false;
+    }
 
-     if (pendingOperation.method.equals(currentMethod)) {
-       // This method is already being handled
-       pendingOperation.responseQueue.add(response);
-     } else {
-       // Only one type of operation can be in progress at a time
-       response.error(ERROR_REASON_OPERATION_IN_PROGRESS, pendingOperation.method, null);
-     }
+    if (pendingOperation.method.equals(currentMethod)) {
+      // This method is already being handled
+      pendingOperation.resultQueue.add(result);
+    } else {
+      // Only one type of operation can be in progress at a time
+      result.error(ERROR_REASON_OPERATION_IN_PROGRESS, pendingOperation.method, null);
+    }
 
-     return true;
-   }
+    return true;
+  }
 
-   /**
-    * Returns the account information for the user who is signed in to this app. If no user is signed
-    * in, tries to sign the user in without displaying any user interface.
-    */
-   private void signInSilently(Response response) {
-     if (checkAndSetPendingOperation(METHOD_SIGN_IN, response)) {
-       return;
-     }
+  /**
+   * Returns the account information for the user who is signed in to this app. If no user is signed
+   * in, tries to sign the user in without displaying any user interface.
+   */
+  private void signInSilently(Result result) {
+    if (checkAndSetPendingOperation(METHOD_SIGN_IN, result)) {
+      return;
+    }
 
-     OptionalPendingResult<GoogleSignInResult> pendingResult =
-         Auth.GoogleSignInApi.silentSignIn(googleApiClient);
-     if (pendingResult.isDone()) {
-       onSignInResult(pendingResult.get());
-     } else {
-       pendingResult.setResultCallback(
-           new ResultCallback<GoogleSignInResult>() {
-             @Override
-             public void onResult(GoogleSignInResult result) {
-               onSignInResult(result);
-             }
-           });
-     }
-   }
+    OptionalPendingResult<GoogleSignInResult> pendingResult =
+        Auth.GoogleSignInApi.silentSignIn(googleApiClient);
+    if (pendingResult.isDone()) {
+      onSignInResult(pendingResult.get());
+    } else {
+      pendingResult.setResultCallback(
+          new ResultCallback<GoogleSignInResult>() {
+            @Override
+            public void onResult(@NonNull GoogleSignInResult signInResult) {
+              onSignInResult(signInResult);
+            }
+          });
+    }
+  }
 
-   /**
-    * Signs the user in via the sign-in user interface, including the OAuth consent flow if scopes
-    * were requested.
-    */
-   private void signIn(Response response) {
-     if (checkAndSetPendingOperation(METHOD_SIGN_IN, response)) {
-       return;
-     }
+  /**
+   * Signs the user in via the sign-in user interface, including the OAuth consent flow if scopes
+   * were requested.
+   */
+  private void signIn(Result result) {
+    if (checkAndSetPendingOperation(METHOD_SIGN_IN, result)) {
+      return;
+    }
 
-     Intent signInIntent = Auth.GoogleSignInApi.getSignInIntent(googleApiClient);
-     activity.startActivityForResult(signInIntent, requestCode);
-   }
+    Intent signInIntent = Auth.GoogleSignInApi.getSignInIntent(googleApiClient);
+    activity.startActivityForResult(signInIntent, requestCode);
+  }
 
-   /**
-    * Gets an OAuth access token with the scopes that were specified during {@link
-    * #init(response,List<String>) initialization} for the user with the specified email
-    * address.
-    */
-   private void getToken(Response response, final String email) {
-     if (email == null) {
-       response.error(ERROR_REASON_EXCEPTION, "Email is null", null);
-       return;
-     }
+  /**
+   * Gets an OAuth access token with the scopes that were specified during {@link
+   * #init(Result, List, String) initialization} for the user with the specified email
+   * address.
+   */
+  private void getToken(Result result, final String email) {
+    if (email == null) {
+      result.error(ERROR_REASON_EXCEPTION, "Email is null", null);
+      return;
+    }
 
-     if (checkAndSetPendingOperation(METHOD_GET_TOKEN, response)) {
-       return;
-     }
+    if (checkAndSetPendingOperation(METHOD_GET_TOKEN, result)) {
+      return;
+    }
 
-     Callable<String> getTokenTask =
-         new Callable<String>() {
-           @Override
-           public String call() throws Exception {
-             Account account = new Account(email, "com.google");
-             String scopesStr = "oauth2:" + Joiner.on(' ').join(requestedScopes);
-             return GoogleAuthUtil.getToken(activity.getApplication(), account, scopesStr);
-           }
-         };
+    Callable<String> getTokenTask =
+        new Callable<String>() {
+          @Override
+          public String call() throws Exception {
+            Account account = new Account(email, "com.google");
+            String scopesStr = "oauth2:" + Joiner.on(' ').join(requestedScopes);
+            return GoogleAuthUtil.getToken(activity.getApplication(), account, scopesStr);
+          }
+        };
 
-     backgroundTaskRunner.runInBackground(
-         getTokenTask,
-         new BackgroundTaskRunner.Callback<String>() {
-           @Override
-           public void run(Future<String> tokenFuture) {
-             try {
-               finishWithSuccess(tokenFuture.get());
-             } catch (ExecutionException e) {
-               Log.e(TAG, "Exception getting access token", e);
-               finishWithError(ERROR_REASON_EXCEPTION, e.getCause().getMessage());
-             } catch (InterruptedException e) {
-               finishWithError(ERROR_REASON_EXCEPTION, e.getMessage());
-             }
-           }
-         });
-   }
+    backgroundTaskRunner.runInBackground(
+        getTokenTask,
+        new BackgroundTaskRunner.Callback<String>() {
+          @Override
+          public void run(Future<String> tokenFuture) {
+            try {
+              finishWithSuccess(tokenFuture.get());
+            } catch (ExecutionException e) {
+              Log.e(TAG, "Exception getting access token", e);
+              finishWithError(ERROR_REASON_EXCEPTION, e.getCause().getMessage());
+            } catch (InterruptedException e) {
+              finishWithError(ERROR_REASON_EXCEPTION, e.getMessage());
+            }
+          }
+        });
+  }
 
-   /**
-    * Signs the user out. Their credentials may remain valid, meaning they'll be able to silently
-    * sign back in.
-    */
-   private void signOut(Response response) {
-     if (checkAndSetPendingOperation(METHOD_SIGN_OUT, response)) {
-       return;
-     }
+  /**
+   * Signs the user out. Their credentials may remain valid, meaning they'll be able to silently
+   * sign back in.
+   */
+  private void signOut(Result result) {
+    if (checkAndSetPendingOperation(METHOD_SIGN_OUT, result)) {
+      return;
+    }
 
-     Auth.GoogleSignInApi.signOut(googleApiClient)
-         .setResultCallback(
-             new ResultCallback<Status>() {
-               @Override
-               public void onResult(Status status) {
-                 // TODO(tvolkert): communicate status back to user
-                 finishWithSuccess(null);
-               }
-             });
-   }
+    Auth.GoogleSignInApi.signOut(googleApiClient)
+        .setResultCallback(
+            new ResultCallback<Status>() {
+              @Override
+              public void onResult(@NonNull Status status) {
+                // TODO(tvolkert): communicate status back to user
+                finishWithSuccess(null);
+              }
+            });
+  }
 
-   /** Signs the user out, and revokes their credentials. */
-   private void disconnect(Response response) {
-     if (checkAndSetPendingOperation(METHOD_DISCONNECT, response)) {
-       return;
-     }
+  /**
+   * Signs the user out, and revokes their credentials.
+   */
+  private void disconnect(Result result) {
+    if (checkAndSetPendingOperation(METHOD_DISCONNECT, result)) {
+      return;
+    }
 
-     Auth.GoogleSignInApi.revokeAccess(googleApiClient)
-         .setResultCallback(
-             new ResultCallback<Status>() {
-               @Override
-               public void onResult(Status status) {
-                 // TODO(tvolkert): communicate status back to user
-                 finishWithSuccess(null);
-               }
-             });
-   }
+    Auth.GoogleSignInApi.revokeAccess(googleApiClient)
+        .setResultCallback(
+            new ResultCallback<Status>() {
+              @Override
+              public void onResult(@NonNull Status status) {
+                // TODO(tvolkert): communicate status back to user
+                finishWithSuccess(null);
+              }
+            });
+  }
 
-   /**
-    * Invoked when the GMS client has successfully connected to the GMS server. This signals that
-    * this listener is properly initialized.
-    */
-   @Override
-   public void onConnected(Bundle connectionHint) {
-     // We can get reconnected if, e.g. the activity is paused and resumed.
-     if (pendingOperation != null && pendingOperation.method.equals(METHOD_INIT)) {
-       finishWithSuccess(null);
-     }
-   }
+  /**
+   * Invoked when the GMS client has successfully connected to the GMS server. This signals that
+   * this listener is properly initialized.
+   */
+  @Override
+  public void onConnected(Bundle connectionHint) {
+    // We can get reconnected if, e.g. the activity is paused and resumed.
+    if (pendingOperation != null && pendingOperation.method.equals(METHOD_INIT)) {
+      finishWithSuccess(null);
+    }
+  }
 
-   /**
-    * Invoked when the GMS client was unable to connect to the GMS server, either because of an error
-    * the user was unable to resolve, or because the user canceled the resolution (e.g. cancelling a
-    * dialog instructing them to upgrade Google Play Services). This signals that we were unable to
-    * properly initialize this listener.
-    */
-   @Override
-   public void onConnectionFailed(@NonNull ConnectionResult result) {
-     // We can attempt to reconnect if, e.g. the activity is paused and resumed.
-     if (pendingOperation != null && pendingOperation.method.equals(METHOD_INIT)) {
-       finishWithError(ERROR_REASON_CONNECTION_FAILED, result.toString());
-     }
-   }
+  /**
+   * Invoked when the GMS client was unable to connect to the GMS server, either because of an error
+   * the user was unable to resolve, or because the user canceled the resolution (e.g. cancelling a
+   * dialog instructing them to upgrade Google Play Services). This signals that we were unable to
+   * properly initialize this listener.
+   */
+  @Override
+  public void onConnectionFailed(@NonNull ConnectionResult result) {
+    // We can attempt to reconnect if, e.g. the activity is paused and resumed.
+    if (pendingOperation != null && pendingOperation.method.equals(METHOD_INIT)) {
+      finishWithError(ERROR_REASON_CONNECTION_FAILED, result.toString());
+    }
+  }
 
-   @Override
-   public void onConnectionSuspended(int cause) {
-     // TODO(jackson): implement
-     Log.w(TAG, "The GMS server connection has been suspended (" + cause + ")");
-   }
+  @Override
+  public void onConnectionSuspended(int cause) {
+    // TODO(jackson): implement
+    Log.w(TAG, "The GMS server connection has been suspended (" + cause + ")");
+  }
 
-   public void onActivityResult(int requestCode, int resultCode, Intent data) {
-     if (requestCode != this.requestCode) {
-       // We're only interested in the "sign in" activity result
-       return;
-     }
+  public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    if (requestCode != this.requestCode) {
+      // We're only interested in the "sign in" activity result
+      return;
+    }
 
-     if (pendingOperation == null || !pendingOperation.method.equals(METHOD_SIGN_IN)) {
-       Log.w(TAG, "Unexpected activity result; sign-in not in progress");
-       return;
-     }
+    if (pendingOperation == null || !pendingOperation.method.equals(METHOD_SIGN_IN)) {
+      Log.w(TAG, "Unexpected activity result; sign-in not in progress");
+      return;
+    }
 
-     if (resultCode != Activity.RESULT_OK) {
-       finishWithError(ERROR_REASON_CANCELED, String.valueOf(resultCode));
-       return;
-     }
+    if (resultCode != Activity.RESULT_OK) {
+      finishWithError(ERROR_REASON_CANCELED, String.valueOf(resultCode));
+      return;
+    }
 
-     onSignInResult(Auth.GoogleSignInApi.getSignInResultFromIntent(data));
-   }
+    onSignInResult(Auth.GoogleSignInApi.getSignInResultFromIntent(data));
+  }
 
-   private void onSignInResult(GoogleSignInResult result) {
-     if (result.isSuccess()) {
-       finishWithSuccess(getSignInResponse(result.getSignInAccount()));
-     } else {
-       finishWithSuccess(null);
-       // TODO(jackson): Communicate status about reason for failure, e.g.
-       // finishWithError(ERROR_REASON_STATUS, result.getStatus().toString());
-     }
-   }
+  private void onSignInResult(GoogleSignInResult result) {
+    if (result.isSuccess()) {
+      finishWithSuccess(getSignInResponse(result.getSignInAccount()));
+    } else {
+      finishWithSuccess(null);
+      // TODO(jackson): Communicate status about reason for failure, e.g.
+      // finishWithError(ERROR_REASON_STATUS, result.getStatus().toString());
+    }
+  }
 
   private static HashMap<String, String> getSignInResponse(GoogleSignInAccount account) {
-    HashMap result = new HashMap<String, String>();
+    HashMap<String, String> result = new HashMap<>();
     result.put("displayName", account.getDisplayName());
     result.put("email", account.getEmail());
     result.put("id", account.getId());
     Uri photoUrl = account.getPhotoUrl();
     result.put("photoUrl", photoUrl != null ? photoUrl.toString() : null);
     return result;
-   }
+  }
 
-   private void finishWithSuccess(Object result) {
-     for (Response response : pendingOperation.responseQueue) {
-       response.success(result);
-     }
-     pendingOperation = null;
-   }
+  private void finishWithSuccess(Object data) {
+    for (Result result : pendingOperation.resultQueue) {
+      result.success(data);
+    }
+    pendingOperation = null;
+  }
 
-   private void finishWithError(String errorCode, String errorMessage) {
-     for (Response response : pendingOperation.responseQueue) {
-       response.error(errorCode, errorMessage, null);
-     }
-     pendingOperation = null;
-   }
- }
+  private void finishWithError(String errorCode, String errorMessage) {
+    for (Result result : pendingOperation.resultQueue) {
+      result.error(errorCode, errorMessage, null);
+    }
+    pendingOperation = null;
+  }
+
+  private class GoogleApiClientConnectionManager implements ActivityLifecycleCallbacks {
+    @Override
+    public void onActivityCreated(Activity activity, Bundle bundle) {
+    }
+
+    @Override
+    public void onActivityDestroyed(Activity activity) {
+    }
+
+    @Override
+    public void onActivityPaused(Activity activity) {
+    }
+
+    @Override
+    public void onActivityResumed(Activity activity) {
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+    }
+
+    @Override
+    public void onActivityStarted(Activity activity) {
+      if (activity == GoogleSignInPlugin.this.activity && googleApiClient != null) {
+        googleApiClient.connect();
+      }
+    }
+
+    @Override
+    public void onActivityStopped(Activity activity) {
+      if (activity == GoogleSignInPlugin.this.activity && googleApiClient != null) {
+        googleApiClient.disconnect();
+      }
+    }
+  }
+
+}

--- a/example/android/.gitignore
+++ b/example/android/.gitignore
@@ -6,9 +6,8 @@
 .DS_Store
 /build
 /captures
+PluginRegistry.java
 
 /gradle
 /gradlew
 /gradlew.bat
-
-app/src/main/java/io/flutter/plugins/PluginRegistry.java

--- a/example/android/.gitignore
+++ b/example/android/.gitignore
@@ -10,3 +10,5 @@
 /gradle
 /gradlew
 /gradlew.bat
+
+app/src/main/java/io/flutter/plugins/PluginRegistry.java

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -23,7 +23,7 @@ android {
     }
 
     defaultConfig {
-    applicationId "com.yourcompany.googlesignin.example"
+        applicationId "com.yourcompany.googlesignin.example"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -38,10 +38,4 @@ android {
 
 flutter {
     source '../..'
-}
-
-dependencies {
-    androidTestCompile 'com.android.support:support-annotations:25.0.0'
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/example/android/app/google-services.json
+++ b/example/android/app/google-services.json
@@ -1,0 +1,48 @@
+{
+  "project_info": {
+    "project_number": "749311722415",
+    "project_id": "project--7261093358044615615"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:749311722415:android:27717105cac89fff",
+        "android_client_info": {
+          "package_name": "com.yourcompany.googlesignin.example"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "749311722415-ct72u40f7rh2un69vs40t9rea28tp508.apps.googleusercontent.com",
+          "client_type": 3
+        },
+        {
+          "client_id": "749311722415-0itscrl7g109cphgujpp3214lm1ham75.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.yourcompany.googlesignin.example",
+            "certificate_hash": "329274e93660a35697463bd44f4e7deaf54f6cd4"
+          }
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAGBeSAi0l2TwQ38UGzWNpmBsimi0sb3qA"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 1
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.1'
     }
 }
 

--- a/example/ios/.gitignore
+++ b/example/ios/.gitignore
@@ -9,6 +9,8 @@ profile
 
 DerivedData/
 build/
+PluginRegistry.h
+PluginRegistry.m
 
 *.pbxuser
 *.mode1v3
@@ -30,13 +32,10 @@ Icon?
 .tags*
 
 /Flutter/app.flx
-/Flutter/app.dylib
 /Flutter/app.zip
 /Flutter/App.framework
 /Flutter/Flutter.framework
 /Flutter/Generated.xcconfig
 /ServiceDefinitions.json
-Runner/PluginRegistry.*
 
-Podfile.lock
 Pods/

--- a/example/ios/.gitignore
+++ b/example/ios/.gitignore
@@ -36,6 +36,7 @@ Icon?
 /Flutter/Flutter.framework
 /Flutter/Generated.xcconfig
 /ServiceDefinitions.json
+Runner/PluginRegistry.*
 
 Podfile.lock
 Pods/

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert' show JSON;
-import 'dart:io' show Platform;
 
 import "package:http/http.dart" as http;
 import 'package:flutter/material.dart';
@@ -94,7 +93,11 @@ class SignInDemoState extends State<SignInDemo> {
 
   Future<Null> _handleSignIn() async {
     GoogleSignIn googleSignIn = await GoogleSignIn.instance;
-    googleSignIn.signIn();
+    try {
+      final account = await googleSignIn.signIn();
+    } catch (error) {
+      print(error);
+    }
   }
 
   Future<Null> _handleSignOut() async {

--- a/lib/google_sign_in.dart
+++ b/lib/google_sign_in.dart
@@ -3,9 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' show Platform;
 
-import 'package:flutter/services.dart' show PlatformMethodChannel;
+import 'package:flutter/services.dart' show MethodChannel;
 import 'package:flutter/material.dart';
 
 class GoogleSignInAccount {
@@ -58,8 +57,8 @@ class GoogleSignInAccount {
 
 /// GoogleSignIn allows you to authenticate Google users.
 class GoogleSignIn {
-  static const PlatformMethodChannel _channel =
-      const PlatformMethodChannel('plugins.flutter.io/google_sign_in');
+  static const MethodChannel _channel =
+      const MethodChannel('plugins.flutter.io/google_sign_in');
   static List<String> _scopes;
   static String _hostedDomain;
 


### PR DESCRIPTION
This works, but doesn't handle gracefully error situations, such as:

- Google Play Services is out-of-date and needs an update
- Airplane mode

This is probably what `enableAutoManage` handles out-of-the-box. We should add proper support for it at some point, but this should unblock users wanting to give Google Sign In a try.

Fixes https://github.com/flutter/flutter/issues/9125
Fixes https://github.com/flutter/flutter/issues/799

@collinjackson 